### PR TITLE
game_info: Parse gatekeeper SGFs

### DIFF
--- a/go_attack_utils/src/sgf_parser/game_info.py
+++ b/go_attack_utils/src/sgf_parser/game_info.py
@@ -198,6 +198,7 @@ def parse_game_str_to_dict(
     )
     victim_visits = {"b": b_visits, "w": w_visits}[victim_color]
     adv_visits = {"b": b_visits, "w": w_visits}[adv_color]
+    adv_komi = komi * {"w": 1, "b": -1}[adv_color]
     if win_color is None:
         adv_minus_victim_score = 0
     else:
@@ -209,17 +210,19 @@ def parse_game_str_to_dict(
         )
         if win_score_str == "R":
             # Resignation
-            win_score = 0
+            win_score = None
+            adv_minus_victim_score = None
+            adv_minus_victim_score_wo_komi = None
         else:
             win_score = float(win_score_str)
-        adv_minus_victim_score = win_score if adv_color == win_color else -win_score
+            adv_minus_victim_score = win_score if adv_color == win_color else -win_score
+            adv_minus_victim_score_wo_komi = adv_minus_victim_score - adv_komi
     adv_steps = (
         extract_re(r"\-s([0-9]+)\-", adv_name)
         or extract_re(r"t0\-s([0-9]+)\-", "/".join(parts[-3:]))
         or 0
     )
     adv_samples = extract_re(r"\-d([0-9]+)", adv_name) or 0
-    adv_komi = komi * {"w": 1, "b": -1}[adv_color]
 
     parsed_info = {
         "b_name": b_name,
@@ -251,7 +254,7 @@ def parse_game_str_to_dict(
         "komi": komi,
         "adv_komi": adv_komi,
         "adv_minus_victim_score": adv_minus_victim_score,
-        "adv_minus_victim_score_wo_komi": adv_minus_victim_score - adv_komi,
+        "adv_minus_victim_score_wo_komi": adv_minus_victim_score_wo_komi,
         # Other info
         "train_status": training,
         "board_size": board_size,

--- a/streamlit_app/parsing_server.py
+++ b/streamlit_app/parsing_server.py
@@ -16,7 +16,6 @@ def load_and_parse_games(path: str, fast_parse: bool = False):
         return pd.DataFrame()
     container_path = MOUNT_DIR / Path(path).relative_to(READ_DIR)
     sgf_paths = game_info.find_sgf_files(container_path)
-    sgf_paths = [p for p in sgf_paths if "gatekeepersgf" not in p.parts]
     print(f"Found {len(sgf_paths)} SGF files in {container_path}")
     parsed_dicts = game_info.read_and_parse_all_files(
         sgf_paths, fast_parse=fast_parse, processes=min(128, len(sgf_paths) // 2)

--- a/streamlit_app/parsing_server.py
+++ b/streamlit_app/parsing_server.py
@@ -16,6 +16,7 @@ def load_and_parse_games(path: str, fast_parse: bool = False):
         return pd.DataFrame()
     container_path = MOUNT_DIR / Path(path).relative_to(READ_DIR)
     sgf_paths = game_info.find_sgf_files(container_path)
+    sgf_paths = [p for p in sgf_paths if "gatekeepersgf" not in p.parts]
     print(f"Found {len(sgf_paths)} SGF files in {container_path}")
     parsed_dicts = game_info.read_and_parse_all_files(
         sgf_paths, fast_parse=fast_parse, processes=min(128, len(sgf_paths) // 2)


### PR DESCRIPTION
* In a dataframe of games, mark `train_status` column as `gating` if the game is a gatekeeping game
* Don't crash on parsing `win_score` if the result is a resignation.
  * (arguably I should turn off resignation in gatekeeping games but either way it's not good to crash on resignation games)