### PR TITLE
Add notebooks that estimate total FLOPs used by KataGo and us

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "submodules/KataGo-pytorch-rewrite"]
-	path = submodules/KataGo-pytorch-rewrite
+	path = submodules/KataGo
 	url = https://github.com/lightvector/KataGo.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodules/KataGo-pytorch-rewrite"]
+	path = submodules/KataGo-pytorch-rewrite
+	url = https://github.com/lightvector/KataGo.git

--- a/go_attack_utils/src/sgf_parser/game_info.py
+++ b/go_attack_utils/src/sgf_parser/game_info.py
@@ -201,6 +201,7 @@ def parse_game_str_to_dict(
     adv_komi = komi * {"w": 1, "b": -1}[adv_color]
     if win_color is None:
         adv_minus_victim_score = 0
+        adv_minus_victim_score_wo_komi = None
     else:
         win_score_str = (
             result.split("+")[-1]

--- a/notebooks/Dockerfile
+++ b/notebooks/Dockerfile
@@ -1,13 +1,15 @@
 # To build, navigate to the *root* of this repo and run:
 # docker build . -f notebooks/Dockerfile -t humancompatibleai/katagovisualizer:notebooks
 
-FROM python:3.10-slim
+FROM nvidia/cuda:11.7.1-runtime-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install utilities
 RUN apt-get update -q \
   && apt-get install -y \
+  # python
+  python3.10-venv \
   # latex
   texlive-latex-extra \
   texlive-fonts-recommended \

--- a/notebooks/docker-compose.yml
+++ b/notebooks/docker-compose.yml
@@ -20,4 +20,11 @@ services:
         read_only: true
     cap_add:
       - SYS_PTRACE  # to enable gdb debugging
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: ["gpu"]
+              driver: nvidia
+              device_ids: ["1"]
     tty: true

--- a/notebooks/notebooks/iclr2022/estimate-compute.ipynb
+++ b/notebooks/notebooks/iclr2022/estimate-compute.ipynb
@@ -1,0 +1,330 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook allows one to estimate the compute involved in training a model."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import datetime\n",
+    "import os\n",
+    "import pathlib\n",
+    "import sys\n",
+    "import torch\n",
+    "from typing import Dict, Union\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from sgf_parser import game_info\n",
+    "import git.repo\n",
+    "\n",
+    "GIT_ROOT = pathlib.Path(\n",
+    "    str(git.repo.Repo(\".\", search_parent_directories=True).working_tree_dir)\n",
+    ")\n",
+    "sys.path.append(str(GIT_ROOT))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load training run data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_game_infos(data_dir: str):\n",
+    "    sgf_paths = game_info.find_sgf_files(root=pathlib.Path(f\"{data_dir}/selfplay\"))\n",
+    "    return game_info.read_and_parse_all_files(\n",
+    "        sgf_paths,\n",
+    "        fast_parse=True,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "201896"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Training run for passing adversary\n",
+    "GAME_INFOS_PASS = get_game_infos(\"/nas/ucb/tony/go-attack/training/emcts1-curr/cp127-to-505-v1\")\n",
+    "len(GAME_INFOS_PASS)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1015527"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Training run for cyclic adversary\n",
+    "# https://www.notion.so/chaiberkeley/adv-b6-600-vs-avoid-pass-alive-v1-curriculum-start-at-cp39-again-ba7cb9bd348d409db3e6fb9c89a56227\n",
+    "GAME_INFOS_DEF = get_game_infos(\"/nas/ucb/k8/go-attack/victimplay/ttseng-avoid-pass-alive-coldstart-39-20221025-175949\")\n",
+    "len(GAME_INFOS_DEF)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Estimate compute"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "adv: b6c96 600\n",
+      "victim: b40c256 4096\n",
+      "# moves: 401\n",
+      "adv flops: 713618478906940.6\n",
+      "victim flops: 2.7435039207319132e+16\n",
+      "2.814865768622607e+16\n",
+      "\n",
+      "adv: b6c96 600\n",
+      "victim: b40c256 1\n",
+      "# moves: 28\n",
+      "adv flops: 6216507521825.897\n",
+      "victim flops: 467691305065.54395\n",
+      "6684198826891.441\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Computed in the estimate-flops.ipynb notebook\n",
+    "MACS_DICT = {\n",
+    "    \"b10c128\": 1052902056.7067871,\n",
+    "    \"b15c192\": 3535965536.369873,\n",
+    "    \"b20c256\": 8392483407.783936,\n",
+    "    \"b40c256\": 16703260895.197998,\n",
+    "    \"b60c320\": 38884293414.61206,\n",
+    "    \"b6c96\": 350317665.0437012,\n",
+    "    \"random\": 0,\n",
+    "}\n",
+    "\n",
+    "def compute_flops(\n",
+    "    info: Dict[str, Union[str, int]],\n",
+    "    verbose: bool = False,\n",
+    ") -> float:\n",
+    "    adv_net_size: str = \"b6c96\" if info[\"adv_name\"] != \"random\" else \"random\"\n",
+    "    adv_visits: int = int(info[\"adv_visits\"]) if info[\"adv_visits\"] is not None else 600\n",
+    "\n",
+    "    victim_net_size: str = info[\"victim_name\"].split(\"-\")[2]  # type: ignore\n",
+    "    if victim_net_size.endswith(\"x2\"):\n",
+    "        victim_net_size = victim_net_size[:-2]\n",
+    "    victim_visits: int = int(info[\"victim_visits\"])\n",
+    "\n",
+    "    num_moves: int = int(info[\"num_moves\"])\n",
+    "    adv_moves = num_moves / 2\n",
+    "    victim_moves = num_moves / 2\n",
+    "\n",
+    "    # 2 flops per MAC\n",
+    "    adv_flops = (\n",
+    "        2\n",
+    "        * adv_moves\n",
+    "        * (\n",
+    "            MACS_DICT[adv_net_size] * adv_visits / 2\n",
+    "            + MACS_DICT[victim_net_size] * adv_moves / 2\n",
+    "        )\n",
+    "    )\n",
+    "\n",
+    "    victim_flops = 2 * victim_moves * MACS_DICT[victim_net_size] * victim_visits\n",
+    "\n",
+    "    if verbose:\n",
+    "        print(\"adv:\", adv_net_size, adv_visits)\n",
+    "        print(\"victim:\", victim_net_size, victim_visits)\n",
+    "        print(\"# moves:\", num_moves)\n",
+    "        print(\"adv flops:\", adv_flops)\n",
+    "        print(\"victim flops:\", victim_flops)\n",
+    "\n",
+    "    return adv_flops + victim_flops\n",
+    "\n",
+    "print(compute_flops(GAME_INFOS_DEF[135010], verbose=True))\n",
+    "print()\n",
+    "print(compute_flops(GAME_INFOS_PASS[50], verbose=True))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pass run stats\n",
+      "Tot moves: 22254080\n",
+      "Tot rows: 15021246\n",
+      "Moves / row: 1.481506926922041\n",
+      "\n",
+      "Def run stats\n",
+      "Tot moves: 305358437\n",
+      "Tot rows: 137006591\n",
+      "Moves / row: 2.2287864749514132\n"
+     ]
+    }
+   ],
+   "source": [
+    "def count_rows_and_moves(game_infos):\n",
+    "    tot_moves = sum(info[\"num_moves\"] for info in game_infos)\n",
+    "    tot_rows = max(\n",
+    "        int(info[\"adv_name\"].split(\"-\")[2].lstrip(\"d\"))\n",
+    "        for info in game_infos\n",
+    "        if info[\"adv_name\"] != \"random\"\n",
+    "    )\n",
+    "\n",
+    "    # There are roughly 2x as many moves as rows,\n",
+    "    # since we only train on moves made by the adversary.\n",
+    "    print(\"Tot moves:\", tot_moves)\n",
+    "    print(\"Tot rows:\", tot_rows)\n",
+    "    print(\"Moves / row:\", tot_moves / tot_rows)\n",
+    "\n",
+    "print(\"Pass run stats\")\n",
+    "count_rows_and_moves(GAME_INFOS_PASS)\n",
+    "\n",
+    "print()\n",
+    "print(\"Def run stats\")\n",
+    "count_rows_and_moves(GAME_INFOS_DEF)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pass run: Total FLOPs\n",
+      "1.9675429524145005e+19\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Pass run: Total FLOPs\")\n",
+    "print(sum(compute_flops(info) for info in GAME_INFOS_PASS))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Def run: FLOPs up to playing against victim with 256 moves\n",
+      "3.88052982120949e+20\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Def run: FLOPs up to playing against victim with 256 moves\")\n",
+    "print(sum(compute_flops(info) for info in GAME_INFOS_DEF if int(info[\"victim_visits\"]) <= 256))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Def run: FLOPs up to 1mil visit experiment adversary\n",
+      "8.733947567117962e+21\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Compute up to t0-s545065216-d136760487\n",
+    "# which was used in the 1mil/10mil experiments.\n",
+    "# https://www.notion.so/chaiberkeley/match-adv-s545m-v600-vs-cp505-v1mil-10search_threads-50ccb5697f404c559a1763b7cfa759ef\n",
+    "print(\"Def run: FLOPs up to 1mil visit experiment adversary\")\n",
+    "print(sum(compute_flops(info) for info in GAME_INFOS_DEF if int(info[\"adv_steps\"]) <= 545065216))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "go-attack",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.13"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "18ad8d816b0438bcdfb77328a8ad028de3abbf4e5e2b82a5cc55004434e63d0c"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/notebooks/iclr2022/estimate-flops-adv.ipynb
+++ b/notebooks/notebooks/iclr2022/estimate-flops-adv.ipynb
@@ -81,7 +81,7 @@
     {
      "data": {
       "text/plain": [
-       "1015622"
+       "1015665"
       ]
      },
      "execution_count": 4,
@@ -146,32 +146,37 @@
     "\n",
     "\n",
     "def compute_flops(\n",
-    "    info: dict[str, int | str],\n",
+    "    game_info: dict[str, int | str],\n",
     "    adv_net_size: str,\n",
     "    verbose: bool = False,\n",
     ") -> float:\n",
     "    \"\"\"\n",
-    "    Given an game info dict, returns the number of flops used in that game.\n",
+    "    Given a game_info dict, returns the number of flops used in that game.\n",
     "\n",
     "    Assumes a constant adv_net_size.\n",
     "    \"\"\"\n",
     "\n",
-    "    if info[\"adv_name\"] == \"random\":\n",
+    "    if game_info[\"adv_name\"] == \"random\":\n",
     "        adv_net_size = \"random\"\n",
     "    assert adv_net_size in MACS_DICT\n",
     "\n",
-    "    adv_visits: int = int(info[\"adv_visits\"]) if info[\"adv_visits\"] is not None else 600\n",
+    "    adv_visits: int = (\n",
+    "        int(game_info[\"adv_visits\"]) if game_info[\"adv_visits\"] is not None else 600\n",
+    "    )\n",
     "\n",
-    "    victim_net_size: str = info[\"victim_name\"].split(\"-\")[2]  # type: ignore\n",
+    "    victim_net_size: str = game_info[\"victim_name\"].split(\"-\")[2]  # type: ignore\n",
     "    if victim_net_size.endswith(\"x2\"):\n",
     "        victim_net_size = victim_net_size[:-2]\n",
-    "    victim_visits: int = int(info[\"victim_visits\"])\n",
+    "    victim_visits: int = int(game_info[\"victim_visits\"])\n",
     "\n",
-    "    num_moves: int = int(info[\"num_moves\"])\n",
+    "    num_moves: int = int(game_info[\"num_moves\"])\n",
     "    adv_moves = num_moves / 2\n",
     "    victim_moves = num_moves / 2\n",
     "\n",
     "    # 2 flops per MAC\n",
+    "    # For A-MCTS-S, we assume half the nodes are adversary and half are victim.\n",
+    "    # This is only approximately true due to things like NN-cache effects,\n",
+    "    # terminal nodes not taking any compute, etc.\n",
     "    adv_flops = (\n",
     "        2\n",
     "        * adv_moves\n",
@@ -179,6 +184,7 @@
     "        * ((MACS_DICT[adv_net_size] + MACS_DICT[victim_net_size]) / 2)\n",
     "    )\n",
     "\n",
+    "    # 2 flops per MAC\n",
     "    victim_flops = 2 * victim_moves * victim_visits * MACS_DICT[victim_net_size]\n",
     "\n",
     "    if verbose:\n",
@@ -211,9 +217,9 @@
       "Moves / row: 1.481506926922041\n",
       "\n",
       "Def run stats\n",
-      "Tot moves: 305376648\n",
+      "Tot moves: 305378095\n",
       "Tot rows: 137006591\n",
-      "Moves / row: 2.2289193955639695\n"
+      "Moves / row: 2.228929957099655\n"
      ]
     }
    ],

--- a/notebooks/notebooks/iclr2022/estimate-flops-adv.ipynb
+++ b/notebooks/notebooks/iclr2022/estimate-flops-adv.ipynb
@@ -22,23 +22,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import datetime\n",
-    "import os\n",
     "import pathlib\n",
-    "import sys\n",
-    "import torch\n",
     "from typing import Dict, Union\n",
     "\n",
-    "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "import pandas as pd\n",
-    "from sgf_parser import game_info\n",
-    "import git.repo\n",
-    "\n",
-    "GIT_ROOT = pathlib.Path(\n",
-    "    str(git.repo.Repo(\".\", search_parent_directories=True).working_tree_dir)\n",
-    ")\n",
-    "sys.path.append(str(GIT_ROOT))"
+    "from sgf_parser import game_info"
    ]
   },
   {
@@ -81,7 +68,9 @@
    ],
    "source": [
     "# Training run for passing adversary\n",
-    "GAME_INFOS_PASS = get_game_infos(\"/nas/ucb/tony/go-attack/training/emcts1-curr/cp127-to-505-v1\")\n",
+    "GAME_INFOS_PASS = get_game_infos(\n",
+    "    \"/nas/ucb/tony/go-attack/training/emcts1-curr/cp127-to-505-v1\"\n",
+    ")\n",
     "len(GAME_INFOS_PASS)"
    ]
   },
@@ -93,7 +82,7 @@
     {
      "data": {
       "text/plain": [
-       "1015527"
+       "1015529"
       ]
      },
      "execution_count": 4,
@@ -104,7 +93,9 @@
    "source": [
     "# Training run for cyclic adversary\n",
     "# https://www.notion.so/chaiberkeley/adv-b6-600-vs-avoid-pass-alive-v1-curriculum-start-at-cp39-again-ba7cb9bd348d409db3e6fb9c89a56227\n",
-    "GAME_INFOS_DEF = get_game_infos(\"/nas/ucb/k8/go-attack/victimplay/ttseng-avoid-pass-alive-coldstart-39-20221025-175949\")\n",
+    "GAME_INFOS_DEF = get_game_infos(\n",
+    "    \"/nas/ucb/k8/go-attack/victimplay/ttseng-avoid-pass-alive-coldstart-39-20221025-175949\"\n",
+    ")\n",
     "len(GAME_INFOS_DEF)"
    ]
   },
@@ -153,6 +144,7 @@
     "    \"random\": 0,\n",
     "}\n",
     "\n",
+    "\n",
     "def compute_flops(\n",
     "    info: Dict[str, Union[str, int]],\n",
     "    verbose: bool = False,\n",
@@ -190,6 +182,7 @@
     "\n",
     "    return adv_flops + victim_flops\n",
     "\n",
+    "\n",
     "print(compute_flops(GAME_INFOS_DEF[135010], verbose=True))\n",
     "print()\n",
     "print(compute_flops(GAME_INFOS_PASS[50], verbose=True))"
@@ -210,9 +203,9 @@
       "Moves / row: 1.481506926922041\n",
       "\n",
       "Def run stats\n",
-      "Tot moves: 305358437\n",
+      "Tot moves: 305358809\n",
       "Tot rows: 137006591\n",
-      "Moves / row: 2.2287864749514132\n"
+      "Moves / row: 2.2287891901492536\n"
      ]
     }
    ],
@@ -230,6 +223,7 @@
     "    print(\"Tot moves:\", tot_moves)\n",
     "    print(\"Tot rows:\", tot_rows)\n",
     "    print(\"Moves / row:\", tot_moves / tot_rows)\n",
+    "\n",
     "\n",
     "print(\"Pass run stats\")\n",
     "count_rows_and_moves(GAME_INFOS_PASS)\n",
@@ -274,7 +268,13 @@
    ],
    "source": [
     "print(\"Def run: FLOPs up to playing against victim with 256 moves\")\n",
-    "print(sum(compute_flops(info) for info in GAME_INFOS_DEF if int(info[\"victim_visits\"]) <= 256))"
+    "print(\n",
+    "    sum(\n",
+    "        compute_flops(info)\n",
+    "        for info in GAME_INFOS_DEF\n",
+    "        if int(info[\"victim_visits\"]) <= 256\n",
+    "    )\n",
+    ")"
    ]
   },
   {
@@ -296,7 +296,13 @@
     "# which was used in the 1mil/10mil experiments.\n",
     "# https://www.notion.so/chaiberkeley/match-adv-s545m-v600-vs-cp505-v1mil-10search_threads-50ccb5697f404c559a1763b7cfa759ef\n",
     "print(\"Def run: FLOPs up to 1mil visit experiment adversary\")\n",
-    "print(sum(compute_flops(info) for info in GAME_INFOS_DEF if int(info[\"adv_steps\"]) <= 545065216))"
+    "print(\n",
+    "    sum(\n",
+    "        compute_flops(info)\n",
+    "        for info in GAME_INFOS_DEF\n",
+    "        if int(info[\"adv_steps\"]) <= 545065216\n",
+    "    )\n",
+    ")"
    ]
   }
  ],

--- a/notebooks/notebooks/iclr2022/estimate-flops-adv.ipynb
+++ b/notebooks/notebooks/iclr2022/estimate-flops-adv.ipynb
@@ -23,7 +23,6 @@
    "outputs": [],
    "source": [
     "import pathlib\n",
-    "from typing import Dict, Union\n",
     "\n",
     "from sgf_parser import game_info"
    ]
@@ -82,7 +81,7 @@
     {
      "data": {
       "text/plain": [
-       "1015529"
+       "1015622"
       ]
      },
      "execution_count": 4,
@@ -119,21 +118,23 @@
       "adv: b6c96 600\n",
       "victim: b40c256 4096\n",
       "# moves: 401\n",
-      "adv flops: 713618478906940.6\n",
+      "adv flops: 2051545500797076.5\n",
       "victim flops: 2.7435039207319132e+16\n",
-      "2.814865768622607e+16\n",
+      "2.948658470811621e+16\n",
       "\n",
       "adv: b6c96 600\n",
       "victim: b40c256 1\n",
       "# moves: 28\n",
-      "adv flops: 6216507521825.897\n",
+      "adv flops: 143250059906030.28\n",
       "victim flops: 467691305065.54395\n",
-      "6684198826891.441\n"
+      "143717751211095.8\n"
      ]
     }
    ],
    "source": [
-    "# Computed in the estimate-flops.ipynb notebook\n",
+    "# Computed in the estimate-flops-katago.ipynb notebook\n",
+    "# (output of Cell 8, also stored in a global variable called MACS_DICT)\n",
+    "# The (random: 0 is added by us here).\n",
     "MACS_DICT = {\n",
     "    \"b10c128\": 1052902056.7067871,\n",
     "    \"b15c192\": 3535965536.369873,\n",
@@ -141,15 +142,24 @@
     "    \"b40c256\": 16703260895.197998,\n",
     "    \"b60c320\": 38884293414.61206,\n",
     "    \"b6c96\": 350317665.0437012,\n",
-    "    \"random\": 0,\n",
-    "}\n",
+    "} | {\"random\": 0}\n",
     "\n",
     "\n",
     "def compute_flops(\n",
-    "    info: Dict[str, Union[str, int]],\n",
+    "    info: dict[str, int | str],\n",
+    "    adv_net_size: str,\n",
     "    verbose: bool = False,\n",
     ") -> float:\n",
-    "    adv_net_size: str = \"b6c96\" if info[\"adv_name\"] != \"random\" else \"random\"\n",
+    "    \"\"\"\n",
+    "    Given an game info dict, returns the number of flops used in that game.\n",
+    "\n",
+    "    Assumes a constant adv_net_size.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    if info[\"adv_name\"] == \"random\":\n",
+    "        adv_net_size = \"random\"\n",
+    "    assert adv_net_size in MACS_DICT\n",
+    "\n",
     "    adv_visits: int = int(info[\"adv_visits\"]) if info[\"adv_visits\"] is not None else 600\n",
     "\n",
     "    victim_net_size: str = info[\"victim_name\"].split(\"-\")[2]  # type: ignore\n",
@@ -165,13 +175,11 @@
     "    adv_flops = (\n",
     "        2\n",
     "        * adv_moves\n",
-    "        * (\n",
-    "            MACS_DICT[adv_net_size] * adv_visits / 2\n",
-    "            + MACS_DICT[victim_net_size] * adv_moves / 2\n",
-    "        )\n",
+    "        * adv_visits\n",
+    "        * ((MACS_DICT[adv_net_size] + MACS_DICT[victim_net_size]) / 2)\n",
     "    )\n",
     "\n",
-    "    victim_flops = 2 * victim_moves * MACS_DICT[victim_net_size] * victim_visits\n",
+    "    victim_flops = 2 * victim_moves * victim_visits * MACS_DICT[victim_net_size]\n",
     "\n",
     "    if verbose:\n",
     "        print(\"adv:\", adv_net_size, adv_visits)\n",
@@ -183,9 +191,9 @@
     "    return adv_flops + victim_flops\n",
     "\n",
     "\n",
-    "print(compute_flops(GAME_INFOS_DEF[135010], verbose=True))\n",
+    "print(compute_flops(GAME_INFOS_DEF[135010], adv_net_size=\"b6c96\", verbose=True))\n",
     "print()\n",
-    "print(compute_flops(GAME_INFOS_PASS[50], verbose=True))"
+    "print(compute_flops(GAME_INFOS_PASS[50], adv_net_size=\"b6c96\", verbose=True))"
    ]
   },
   {
@@ -203,9 +211,9 @@
       "Moves / row: 1.481506926922041\n",
       "\n",
       "Def run stats\n",
-      "Tot moves: 305358809\n",
+      "Tot moves: 305376648\n",
       "Tot rows: 137006591\n",
-      "Moves / row: 2.2287891901492536\n"
+      "Moves / row: 2.2289193955639695\n"
      ]
     }
    ],
@@ -243,13 +251,13 @@
      "output_type": "stream",
      "text": [
       "Pass run: Total FLOPs\n",
-      "1.9675429524145005e+19\n"
+      "1.125046864835051e+20\n"
      ]
     }
    ],
    "source": [
     "print(\"Pass run: Total FLOPs\")\n",
-    "print(sum(compute_flops(info) for info in GAME_INFOS_PASS))"
+    "print(sum(compute_flops(info, adv_net_size=\"b6c96\") for info in GAME_INFOS_PASS))"
    ]
   },
   {
@@ -262,7 +270,7 @@
      "output_type": "stream",
      "text": [
       "Def run: FLOPs up to playing against victim with 256 moves\n",
-      "3.88052982120949e+20\n"
+      "1.132901791968054e+21\n"
      ]
     }
    ],
@@ -270,7 +278,7 @@
     "print(\"Def run: FLOPs up to playing against victim with 256 moves\")\n",
     "print(\n",
     "    sum(\n",
-    "        compute_flops(info)\n",
+    "        compute_flops(info, adv_net_size=\"b6c96\")\n",
     "        for info in GAME_INFOS_DEF\n",
     "        if int(info[\"victim_visits\"]) <= 256\n",
     "    )\n",
@@ -287,7 +295,7 @@
      "output_type": "stream",
      "text": [
       "Def run: FLOPs up to 1mil visit experiment adversary\n",
-      "8.733947567117962e+21\n"
+      "9.579539505273113e+21\n"
      ]
     }
    ],
@@ -298,7 +306,7 @@
     "print(\"Def run: FLOPs up to 1mil visit experiment adversary\")\n",
     "print(\n",
     "    sum(\n",
-    "        compute_flops(info)\n",
+    "        compute_flops(info, adv_net_size=\"b6c96\")\n",
     "        for info in GAME_INFOS_DEF\n",
     "        if int(info[\"adv_steps\"]) <= 545065216\n",
     "    )\n",
@@ -308,7 +316,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "go-attack",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
@@ -322,12 +330,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.10.6"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "18ad8d816b0438bcdfb77328a8ad028de3abbf4e5e2b82a5cc55004434e63d0c"
+    "hash": "23393d2575091a37cff0d0e9e7479591a295495b26c3b2ebf9b64da572e02d85"
    }
   }
  },

--- a/notebooks/notebooks/iclr2022/estimate-flops-katago.ipynb
+++ b/notebooks/notebooks/iclr2022/estimate-flops-katago.ipynb
@@ -51,7 +51,7 @@
     "GIT_ROOT = pathlib.Path(\n",
     "    str(git.repo.Repo(\".\", search_parent_directories=True).working_tree_dir)\n",
     ")\n",
-    "sys.path.append(str(GIT_ROOT / \"submodules/KataGo-pytorch-rewrite/python\"))\n",
+    "sys.path.append(str(GIT_ROOT / \"submodules/KataGo/python\"))\n",
     "\n",
     "import modelconfigs\n",
     "from model_pytorch import Model"
@@ -73,7 +73,7 @@
     {
      "data": {
       "text/plain": [
-       "540"
+       "541"
       ]
      },
      "execution_count": 2,
@@ -140,38 +140,38 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
+       "      <td>kata1-b60c320-s6794945792-d3074237803</td>\n",
+       "      <td>b60c320</td>\n",
+       "      <td>6794945792</td>\n",
+       "      <td>3074237803</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
        "      <td>kata1-b60c320-s6782286336-d3070935549</td>\n",
        "      <td>b60c320</td>\n",
        "      <td>6782286336</td>\n",
        "      <td>3070935549</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
+       "      <th>2</th>\n",
        "      <td>kata1-b60c320-s6769829376-d3067673297</td>\n",
        "      <td>b60c320</td>\n",
        "      <td>6769829376</td>\n",
        "      <td>3067673297</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
+       "      <th>3</th>\n",
        "      <td>kata1-b60c320-s6757237760-d3064295323</td>\n",
        "      <td>b60c320</td>\n",
        "      <td>6757237760</td>\n",
        "      <td>3064295323</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
+       "      <th>4</th>\n",
        "      <td>kata1-b60c320-s6744642560-d3061231329</td>\n",
        "      <td>b60c320</td>\n",
        "      <td>6744642560</td>\n",
        "      <td>3061231329</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>kata1-b60c320-s6729327872-d3057177418</td>\n",
-       "      <td>b60c320</td>\n",
-       "      <td>6729327872</td>\n",
-       "      <td>3057177418</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -179,11 +179,11 @@
       ],
       "text/plain": [
        "                                    name net_size       steps        rows\n",
-       "0  kata1-b60c320-s6782286336-d3070935549  b60c320  6782286336  3070935549\n",
-       "1  kata1-b60c320-s6769829376-d3067673297  b60c320  6769829376  3067673297\n",
-       "2  kata1-b60c320-s6757237760-d3064295323  b60c320  6757237760  3064295323\n",
-       "3  kata1-b60c320-s6744642560-d3061231329  b60c320  6744642560  3061231329\n",
-       "4  kata1-b60c320-s6729327872-d3057177418  b60c320  6729327872  3057177418"
+       "0  kata1-b60c320-s6794945792-d3074237803  b60c320  6794945792  3074237803\n",
+       "1  kata1-b60c320-s6782286336-d3070935549  b60c320  6782286336  3070935549\n",
+       "2  kata1-b60c320-s6769829376-d3067673297  b60c320  6769829376  3067673297\n",
+       "3  kata1-b60c320-s6757237760-d3064295323  b60c320  6757237760  3064295323\n",
+       "4  kata1-b60c320-s6744642560-d3061231329  b60c320  6744642560  3061231329"
       ]
      },
      "execution_count": 3,
@@ -312,7 +312,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c9e1395435e24683af2cbe5cdc72f7ea",
+       "model_id": "983f0b0be1dd459baecd350b26955a25",
        "version_major": 2,
        "version_minor": 0
       },

--- a/notebooks/notebooks/iclr2022/estimate-flops-katago.ipynb
+++ b/notebooks/notebooks/iclr2022/estimate-flops-katago.ipynb
@@ -207,7 +207,7 @@
     "\n",
     "# Get unique network sizes\n",
     "df_nets = pd.DataFrame([parse_network_name(x) for x in network_names])\n",
-    "df_nets.head()\n"
+    "df_nets.head()"
    ]
   },
   {
@@ -301,7 +301,7 @@
     "        thop_macs=thop_macs / batch_size,\n",
     "        thop_params=thop_params,\n",
     "        batch_size=batch_size,\n",
-    "    )\n"
+    "    )"
    ]
   },
   {
@@ -312,7 +312,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "df8668f4475d4255a4504e792fcb5a7c",
+       "model_id": "2509a2901f5849f590c6fbfe4ecc1278",
        "version_major": 2,
        "version_minor": 0
       },
@@ -425,7 +425,7 @@
    ],
    "source": [
     "results = []\n",
-    "for net_size in tqdm(df_nets.net_size.unique()): \n",
+    "for net_size in tqdm(df_nets.net_size.unique()):\n",
     "    model_config = modelconfigs.config_of_name[net_size]\n",
     "    model = Model(model_config, 19)\n",
     "    model.initialize()\n",
@@ -546,12 +546,14 @@
    "source": [
     "# Check we get low std in measurements\n",
     "gb = df.groupby(\"net_size\")\n",
-    "df_mean = pd.DataFrame(dict(\n",
-    "    ptflops_mean=gb.ptflops_macs.mean(),\n",
-    "    ptflops_std=gb.ptflops_macs.std(),\n",
-    "    thop_mean=gb.thop_macs.mean(),\n",
-    "    thop_std=gb.thop_macs.std(),\n",
-    "))\n",
+    "df_mean = pd.DataFrame(\n",
+    "    dict(\n",
+    "        ptflops_mean=gb.ptflops_macs.mean(),\n",
+    "        ptflops_std=gb.ptflops_macs.std(),\n",
+    "        thop_mean=gb.thop_macs.mean(),\n",
+    "        thop_std=gb.thop_macs.std(),\n",
+    "    )\n",
+    ")\n",
     "df_mean"
    ]
   },
@@ -612,7 +614,12 @@
     "\n",
     "tot_flops = 0\n",
     "prv_rows = 0\n",
-    "for x in df_nets.query(\"rows <= 2898845681 & net_size != 'b60c320'\").sort_values(\"rows\").reset_index(drop=True).itertuples():\n",
+    "for x in (\n",
+    "    df_nets.query(\"rows <= 2898845681 & net_size != 'b60c320'\")\n",
+    "    .sort_values(\"rows\")\n",
+    "    .reset_index(drop=True)\n",
+    "    .itertuples()\n",
+    "):\n",
     "    cur_rows = x.rows\n",
     "\n",
     "    # 2 FLOPS per MAC\n",

--- a/notebooks/notebooks/iclr2022/estimate-flops-katago.ipynb
+++ b/notebooks/notebooks/iclr2022/estimate-flops-katago.ipynb
@@ -9,10 +9,9 @@
     "we estimate the FLOPs needed to compute the forward pass\n",
     "of various KataGo models.\n",
     "\n",
-    "This notebook needs a GPU to run,\n",
-    "and will not work with the Dockerfiles provided here.\n",
-    "\n",
-    "Tony ran it in a conda environment on rnn after installing ../requirements.txt."
+    "This notebook works in the provided Docker container,\n",
+    "though has only been tested when a GPU is available.\n",
+    "It will probably be very slow without a GPU."
    ]
   },
   {
@@ -34,7 +33,6 @@
     "import pathlib\n",
     "import sys\n",
     "import warnings\n",
-    "from typing import Dict, Union\n",
     "\n",
     "import git.repo\n",
     "import matplotlib.pyplot as plt\n",
@@ -48,6 +46,8 @@
     "from torch import nn\n",
     "from tqdm.auto import tqdm\n",
     "\n",
+    "# We need to import some libraries from upstream KataGo.\n",
+    "# KataGo doesn't have a setup.py, so we modify sys.path instead (kinda hacky).\n",
     "GIT_ROOT = pathlib.Path(\n",
     "    str(git.repo.Repo(\".\", search_parent_directories=True).working_tree_dir)\n",
     ")\n",
@@ -73,7 +73,7 @@
     {
      "data": {
       "text/plain": [
-       "539"
+       "540"
       ]
      },
      "execution_count": 2,
@@ -140,50 +140,50 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
+       "      <td>kata1-b60c320-s6782286336-d3070935549</td>\n",
+       "      <td>b60c320</td>\n",
+       "      <td>6782286336</td>\n",
+       "      <td>3070935549</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
        "      <td>kata1-b60c320-s6769829376-d3067673297</td>\n",
        "      <td>b60c320</td>\n",
        "      <td>6769829376</td>\n",
        "      <td>3067673297</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
+       "      <th>2</th>\n",
        "      <td>kata1-b60c320-s6757237760-d3064295323</td>\n",
        "      <td>b60c320</td>\n",
        "      <td>6757237760</td>\n",
        "      <td>3064295323</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
+       "      <th>3</th>\n",
        "      <td>kata1-b60c320-s6744642560-d3061231329</td>\n",
        "      <td>b60c320</td>\n",
        "      <td>6744642560</td>\n",
        "      <td>3061231329</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
+       "      <th>4</th>\n",
        "      <td>kata1-b60c320-s6729327872-d3057177418</td>\n",
        "      <td>b60c320</td>\n",
        "      <td>6729327872</td>\n",
        "      <td>3057177418</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>kata1-b40c256-s12350780416-d3055274313</td>\n",
-       "      <td>b40c256</td>\n",
-       "      <td>12350780416</td>\n",
-       "      <td>3055274313</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                     name net_size        steps        rows\n",
-       "0   kata1-b60c320-s6769829376-d3067673297  b60c320   6769829376  3067673297\n",
-       "1   kata1-b60c320-s6757237760-d3064295323  b60c320   6757237760  3064295323\n",
-       "2   kata1-b60c320-s6744642560-d3061231329  b60c320   6744642560  3061231329\n",
-       "3   kata1-b60c320-s6729327872-d3057177418  b60c320   6729327872  3057177418\n",
-       "4  kata1-b40c256-s12350780416-d3055274313  b40c256  12350780416  3055274313"
+       "                                    name net_size       steps        rows\n",
+       "0  kata1-b60c320-s6782286336-d3070935549  b60c320  6782286336  3070935549\n",
+       "1  kata1-b60c320-s6769829376-d3067673297  b60c320  6769829376  3067673297\n",
+       "2  kata1-b60c320-s6757237760-d3064295323  b60c320  6757237760  3064295323\n",
+       "3  kata1-b60c320-s6744642560-d3061231329  b60c320  6744642560  3061231329\n",
+       "4  kata1-b60c320-s6729327872-d3057177418  b60c320  6729327872  3057177418"
       ]
      },
      "execution_count": 3,
@@ -192,7 +192,7 @@
     }
    ],
    "source": [
-    "def parse_network_name(name: str) -> Dict[str, Union[str, int]]:\n",
+    "def parse_network_name(name: str) -> dict[str, int | str]:\n",
     "    net_size = name.split(\"-\")[1]\n",
     "    if net_size.endswith(\"x2\"):\n",
     "        net_size = net_size.rstrip(\"x2\")\n",
@@ -204,8 +204,7 @@
     "        rows=int(name.split(\"-\")[3].lstrip(\"d\")),\n",
     "    )\n",
     "\n",
-    "\n",
-    "# Get unique network sizes\n",
+    "# Create dataframe of all network checkpoints\n",
     "df_nets = pd.DataFrame([parse_network_name(x) for x in network_names])\n",
     "df_nets.head()"
    ]
@@ -228,7 +227,8 @@
     }
    ],
    "source": [
-    "df_nets.net_size.unique()"
+    "UNIQUE_NET_SIZES = df_nets.net_size.unique()\n",
+    "UNIQUE_NET_SIZES"
    ]
   },
   {
@@ -259,7 +259,7 @@
     "def measure_macs(\n",
     "    model: nn.Module,\n",
     "    batch_size: int = 256,\n",
-    ") -> Dict[str, Union[float, str]]:\n",
+    ") -> dict[str, float | str]:\n",
     "    \"\"\"Returns macs / batch element.\"\"\"\n",
     "    # Get inputs to model.\n",
     "    # Input shapes obtained via debugging the following command:\n",
@@ -312,7 +312,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2509a2901f5849f590c6fbfe4ecc1278",
+       "model_id": "c9e1395435e24683af2cbe5cdc72f7ea",
        "version_major": 2,
        "version_minor": 0
       },
@@ -425,7 +425,7 @@
    ],
    "source": [
     "results = []\n",
-    "for net_size in tqdm(df_nets.net_size.unique()):\n",
+    "for net_size in tqdm(UNIQUE_NET_SIZES):\n",
     "    model_config = modelconfigs.config_of_name[net_size]\n",
     "    model = Model(model_config, 19)\n",
     "    model.initialize()\n",
@@ -467,10 +467,10 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>ptflops_mean</th>\n",
-       "      <th>ptflops_std</th>\n",
-       "      <th>thop_mean</th>\n",
-       "      <th>thop_std</th>\n",
+       "      <th>ptflops_macs_mean</th>\n",
+       "      <th>ptflops_macs_std</th>\n",
+       "      <th>thop_macs_mean</th>\n",
+       "      <th>thop_macs_std</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>net_size</th>\n",
@@ -528,14 +528,14 @@
        "</div>"
       ],
       "text/plain": [
-       "          ptflops_mean   ptflops_std     thop_mean      thop_std\n",
-       "net_size                                                        \n",
-       "b10c128   1.053432e+09   9348.777258  1.052373e+09   9318.170885\n",
-       "b15c192   3.537091e+09  11684.545004  3.534840e+09  11647.713606\n",
-       "b20c256   8.394444e+09  14019.621081  8.390522e+09  13977.256327\n",
-       "b40c256   1.670709e+10  16354.697158  1.669944e+10  16306.799048\n",
-       "b60c320   3.889138e+10  18689.773234  3.887721e+10  18636.341769\n",
-       "b6c96     3.505805e+08   7013.009512  3.500548e+08   6988.628164"
+       "          ptflops_macs_mean  ptflops_macs_std  thop_macs_mean  thop_macs_std\n",
+       "net_size                                                                    \n",
+       "b10c128        1.053432e+09       9348.777258    1.052373e+09    9318.170885\n",
+       "b15c192        3.537091e+09      11684.545004    3.534840e+09   11647.713606\n",
+       "b20c256        8.394444e+09      14019.621081    8.390522e+09   13977.256327\n",
+       "b40c256        1.670709e+10      16354.697158    1.669944e+10   16306.799048\n",
+       "b60c320        3.889138e+10      18689.773234    3.887721e+10   18636.341769\n",
+       "b6c96          3.505805e+08       7013.009512    3.500548e+08    6988.628164"
       ]
      },
      "execution_count": 7,
@@ -548,10 +548,10 @@
     "gb = df.groupby(\"net_size\")\n",
     "df_mean = pd.DataFrame(\n",
     "    dict(\n",
-    "        ptflops_mean=gb.ptflops_macs.mean(),\n",
-    "        ptflops_std=gb.ptflops_macs.std(),\n",
-    "        thop_mean=gb.thop_macs.mean(),\n",
-    "        thop_std=gb.thop_macs.std(),\n",
+    "        ptflops_macs_mean=gb.ptflops_macs.mean(),\n",
+    "        ptflops_macs_std=gb.ptflops_macs.std(),\n",
+    "        thop_macs_mean=gb.thop_macs.mean(),\n",
+    "        thop_macs_std=gb.thop_macs.std(),\n",
     "    )\n",
     ")\n",
     "df_mean"
@@ -579,9 +579,9 @@
     }
    ],
    "source": [
-    "macs = (df_mean.ptflops_mean + df_mean.thop_mean) / 2\n",
-    "macs_dict = dict(zip(df_mean.index, macs))\n",
-    "macs_dict"
+    "macs = (df_mean.ptflops_macs_mean + df_mean.thop_macs_mean) / 2\n",
+    "MACS_DICT = dict(zip(df_mean.index, macs))\n",
+    "MACS_DICT"
    ]
   },
   {
@@ -609,13 +609,18 @@
     }
    ],
    "source": [
+    "STRONGEST_CONFIDENTLY_RATED_NET = \"kata1-b40c256-s11840935168-d2898845681\"\n",
+    "STRONGEST_CONFIDENTLY_RATED_ROWS = parse_network_name(STRONGEST_CONFIDENTLY_RATED_NET)[\n",
+    "    \"rows\"\n",
+    "]\n",
+    "\n",
     "# https://github.com/lightvector/KataGo/blob/12b8dd4ce74367b4efa4678c9fe11597f55929f5/cpp/configs/training/selfplay8b20.cfg#L96\n",
-    "visits_per_row = 1000\n",
+    "VISITS_PER_ROW = 1000\n",
     "\n",
     "tot_flops = 0\n",
     "prv_rows = 0\n",
     "for x in (\n",
-    "    df_nets.query(\"rows <= 2898845681 & net_size != 'b60c320'\")\n",
+    "    df_nets.query(f\"rows <= {STRONGEST_CONFIDENTLY_RATED_ROWS} & net_size != 'b60c320'\")\n",
     "    .sort_values(\"rows\")\n",
     "    .reset_index(drop=True)\n",
     "    .itertuples()\n",
@@ -623,7 +628,7 @@
     "    cur_rows = x.rows\n",
     "\n",
     "    # 2 FLOPS per MAC\n",
-    "    cur_flops = 2 * macs_dict[x.net_size] * visits_per_row * (cur_rows - prv_rows)\n",
+    "    cur_flops = 2 * MACS_DICT[x.net_size] * VISITS_PER_ROW * (cur_rows - prv_rows)\n",
     "    tot_flops += cur_flops\n",
     "\n",
     "    prv_rows = cur_rows\n",
@@ -634,7 +639,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "go-attack",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
@@ -648,12 +653,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.10.6"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "18ad8d816b0438bcdfb77328a8ad028de3abbf4e5e2b82a5cc55004434e63d0c"
+    "hash": "23393d2575091a37cff0d0e9e7479591a295495b26c3b2ebf9b64da572e02d85"
    }
   }
  },

--- a/notebooks/notebooks/iclr2022/estimate-flops.ipynb
+++ b/notebooks/notebooks/iclr2022/estimate-flops.ipynb
@@ -1,0 +1,655 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this notebook,\n",
+    "we estimate the FLOPs needed to compute the forward pass\n",
+    "of various KataGo models.\n",
+    "\n",
+    "This notebook needs a GPU to run,\n",
+    "and will not work with the Dockerfiles provided here.\n",
+    "\n",
+    "Tony ran it in a conda environment on rnn after installing ../requirements.txt."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import contextlib\n",
+    "import os\n",
+    "import pathlib\n",
+    "import sys\n",
+    "import warnings\n",
+    "from typing import Dict, Union\n",
+    "\n",
+    "import git.repo\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import ptflops\n",
+    "import requests\n",
+    "import thop\n",
+    "import torch\n",
+    "from bs4 import BeautifulSoup\n",
+    "from torch import nn\n",
+    "from tqdm.auto import tqdm\n",
+    "\n",
+    "GIT_ROOT = pathlib.Path(\n",
+    "    str(git.repo.Repo(\".\", search_parent_directories=True).working_tree_dir)\n",
+    ")\n",
+    "sys.path.append(str(GIT_ROOT / \"submodules/KataGo-pytorch-rewrite/python\"))\n",
+    "\n",
+    "import modelconfigs\n",
+    "from model_pytorch import Model"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load KataGo training history"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "539"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Pull data from https://katagotraining.org/networks/\n",
+    "r = requests.get(\"https://katagotraining.org/networks/\")\n",
+    "soup = BeautifulSoup(r.content, \"html.parser\")\n",
+    "\n",
+    "# Get the name of all the networks\n",
+    "network_names = [\n",
+    "    x.td.text.strip()\n",
+    "    for x in soup.find_all(\n",
+    "        \"tr\",\n",
+    "        {\n",
+    "            \"class\": lambda x: x\n",
+    "            in (\n",
+    "                \"normalNetworkStyle\",\n",
+    "                \"strongestNetworkStyle\",\n",
+    "            )\n",
+    "        },\n",
+    "    )\n",
+    "]\n",
+    "assert network_names[-1] == \"kata1-random\"\n",
+    "network_names = network_names[:-1]\n",
+    "len(network_names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>name</th>\n",
+       "      <th>net_size</th>\n",
+       "      <th>steps</th>\n",
+       "      <th>rows</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>kata1-b60c320-s6769829376-d3067673297</td>\n",
+       "      <td>b60c320</td>\n",
+       "      <td>6769829376</td>\n",
+       "      <td>3067673297</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>kata1-b60c320-s6757237760-d3064295323</td>\n",
+       "      <td>b60c320</td>\n",
+       "      <td>6757237760</td>\n",
+       "      <td>3064295323</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>kata1-b60c320-s6744642560-d3061231329</td>\n",
+       "      <td>b60c320</td>\n",
+       "      <td>6744642560</td>\n",
+       "      <td>3061231329</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>kata1-b60c320-s6729327872-d3057177418</td>\n",
+       "      <td>b60c320</td>\n",
+       "      <td>6729327872</td>\n",
+       "      <td>3057177418</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>kata1-b40c256-s12350780416-d3055274313</td>\n",
+       "      <td>b40c256</td>\n",
+       "      <td>12350780416</td>\n",
+       "      <td>3055274313</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                     name net_size        steps        rows\n",
+       "0   kata1-b60c320-s6769829376-d3067673297  b60c320   6769829376  3067673297\n",
+       "1   kata1-b60c320-s6757237760-d3064295323  b60c320   6757237760  3064295323\n",
+       "2   kata1-b60c320-s6744642560-d3061231329  b60c320   6744642560  3061231329\n",
+       "3   kata1-b60c320-s6729327872-d3057177418  b60c320   6729327872  3057177418\n",
+       "4  kata1-b40c256-s12350780416-d3055274313  b40c256  12350780416  3055274313"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def parse_network_name(name: str) -> Dict[str, Union[str, int]]:\n",
+    "    net_size = name.split(\"-\")[1]\n",
+    "    if net_size.endswith(\"x2\"):\n",
+    "        net_size = net_size.rstrip(\"x2\")\n",
+    "\n",
+    "    return dict(\n",
+    "        name=name,\n",
+    "        net_size=net_size,\n",
+    "        steps=int(name.split(\"-\")[2].lstrip(\"s\")),\n",
+    "        rows=int(name.split(\"-\")[3].lstrip(\"d\")),\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "# Get unique network sizes\n",
+    "df_nets = pd.DataFrame([parse_network_name(x) for x in network_names])\n",
+    "df_nets.head()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(['b60c320', 'b40c256', 'b20c256', 'b15c192', 'b10c128', 'b6c96'],\n",
+       "      dtype=object)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_nets.net_size.unique()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Collect FLOP data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class FilteredWriter:\n",
+    "    \"\"\"Filters out an annoying message from ptflops.\"\"\"\n",
+    "\n",
+    "    def write(self, message):\n",
+    "        if message not in (\n",
+    "            \"Warning! No positional inputs found for a module, assuming batch size is 1.\",\n",
+    "            \"\\n\",\n",
+    "        ):\n",
+    "            warnings.warn(message)\n",
+    "\n",
+    "\n",
+    "def measure_macs(\n",
+    "    model: nn.Module,\n",
+    "    batch_size: int = 256,\n",
+    ") -> Dict[str, Union[float, str]]:\n",
+    "    \"\"\"Returns macs / batch element.\"\"\"\n",
+    "    # Get inputs to model.\n",
+    "    # Input shapes obtained via debugging the following command:\n",
+    "    #   python submodules/KataGo-pytorch-rewrite/python/test.py \\\n",
+    "    #     -npzdir /nas/ucb/k8/go-attack/victimplay/ttseng-avoid-pass-alive-coldstart-39-20221025-175949/selfplay/t0-s532017152-d133516007/tdata \\\n",
+    "    #     -model-kind b6c96 \\\n",
+    "    #     -pos-len 19 \\\n",
+    "    #     -batch-size 256\n",
+    "    binaryInputNCHW = torch.randn(batch_size, 22, 19, 19, device=\"cuda\")\n",
+    "    globalInputNC = torch.randn(batch_size, 19, device=\"cuda\")\n",
+    "\n",
+    "    # Measure via ptflops\n",
+    "    ptflops_macs: float\n",
+    "    ptflops_params: float\n",
+    "    with contextlib.redirect_stdout(FilteredWriter()):  # type: ignore\n",
+    "        ptflops_macs, ptflops_params = ptflops.get_model_complexity_info(\n",
+    "            model,\n",
+    "            (1,),\n",
+    "            input_constructor=lambda _: dict(\n",
+    "                input_spatial=binaryInputNCHW,\n",
+    "                input_global=globalInputNC,\n",
+    "            ),\n",
+    "            as_strings=False,\n",
+    "            print_per_layer_stat=False,\n",
+    "        )  # type: ignore\n",
+    "\n",
+    "    # Measure via thop\n",
+    "    thop_macs: float\n",
+    "    thop_params: float\n",
+    "    thop_macs, thop_params = thop.profile(  # type: ignore\n",
+    "        model,\n",
+    "        inputs=(binaryInputNCHW, globalInputNC),\n",
+    "        verbose=False,\n",
+    "    )\n",
+    "\n",
+    "    return dict(\n",
+    "        ptflops_macs=ptflops_macs / batch_size,\n",
+    "        ptflops_params=ptflops_params,\n",
+    "        thop_macs=thop_macs / batch_size,\n",
+    "        thop_params=thop_params,\n",
+    "        batch_size=batch_size,\n",
+    "    )\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "df8668f4475d4255a4504e792fcb5a7c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/6 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ptflops_macs</th>\n",
+       "      <th>ptflops_params</th>\n",
+       "      <th>thop_macs</th>\n",
+       "      <th>thop_params</th>\n",
+       "      <th>batch_size</th>\n",
+       "      <th>net_size</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>3.889142e+10</td>\n",
+       "      <td>108559237</td>\n",
+       "      <td>3.887725e+10</td>\n",
+       "      <td>108502149.0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>b60c320</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>3.889139e+10</td>\n",
+       "      <td>108559237</td>\n",
+       "      <td>3.887722e+10</td>\n",
+       "      <td>108502149.0</td>\n",
+       "      <td>4</td>\n",
+       "      <td>b60c320</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3.889138e+10</td>\n",
+       "      <td>108559237</td>\n",
+       "      <td>3.887721e+10</td>\n",
+       "      <td>108502149.0</td>\n",
+       "      <td>8</td>\n",
+       "      <td>b60c320</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3.889137e+10</td>\n",
+       "      <td>108559237</td>\n",
+       "      <td>3.887720e+10</td>\n",
+       "      <td>108502149.0</td>\n",
+       "      <td>16</td>\n",
+       "      <td>b60c320</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>3.889137e+10</td>\n",
+       "      <td>108559237</td>\n",
+       "      <td>3.887720e+10</td>\n",
+       "      <td>108502149.0</td>\n",
+       "      <td>32</td>\n",
+       "      <td>b60c320</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   ptflops_macs  ptflops_params     thop_macs  thop_params  batch_size  \\\n",
+       "0  3.889142e+10       108559237  3.887725e+10  108502149.0           2   \n",
+       "1  3.889139e+10       108559237  3.887722e+10  108502149.0           4   \n",
+       "2  3.889138e+10       108559237  3.887721e+10  108502149.0           8   \n",
+       "3  3.889137e+10       108559237  3.887720e+10  108502149.0          16   \n",
+       "4  3.889137e+10       108559237  3.887720e+10  108502149.0          32   \n",
+       "\n",
+       "  net_size  \n",
+       "0  b60c320  \n",
+       "1  b60c320  \n",
+       "2  b60c320  \n",
+       "3  b60c320  \n",
+       "4  b60c320  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results = []\n",
+    "for net_size in tqdm(df_nets.net_size.unique()): \n",
+    "    model_config = modelconfigs.config_of_name[net_size]\n",
+    "    model = Model(model_config, 19)\n",
+    "    model.initialize()\n",
+    "    model.cuda()\n",
+    "    model.eval()\n",
+    "\n",
+    "    for batch_size in [2, 4, 8, 16, 32, 64, 128, 256]:\n",
+    "        res = measure_macs(model, batch_size=batch_size)\n",
+    "        res[\"net_size\"] = net_size\n",
+    "        results.append(res)\n",
+    "\n",
+    "df = pd.DataFrame(results)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ptflops_mean</th>\n",
+       "      <th>ptflops_std</th>\n",
+       "      <th>thop_mean</th>\n",
+       "      <th>thop_std</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>net_size</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>b10c128</th>\n",
+       "      <td>1.053432e+09</td>\n",
+       "      <td>9348.777258</td>\n",
+       "      <td>1.052373e+09</td>\n",
+       "      <td>9318.170885</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>b15c192</th>\n",
+       "      <td>3.537091e+09</td>\n",
+       "      <td>11684.545004</td>\n",
+       "      <td>3.534840e+09</td>\n",
+       "      <td>11647.713606</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>b20c256</th>\n",
+       "      <td>8.394444e+09</td>\n",
+       "      <td>14019.621081</td>\n",
+       "      <td>8.390522e+09</td>\n",
+       "      <td>13977.256327</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>b40c256</th>\n",
+       "      <td>1.670709e+10</td>\n",
+       "      <td>16354.697158</td>\n",
+       "      <td>1.669944e+10</td>\n",
+       "      <td>16306.799048</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>b60c320</th>\n",
+       "      <td>3.889138e+10</td>\n",
+       "      <td>18689.773234</td>\n",
+       "      <td>3.887721e+10</td>\n",
+       "      <td>18636.341769</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>b6c96</th>\n",
+       "      <td>3.505805e+08</td>\n",
+       "      <td>7013.009512</td>\n",
+       "      <td>3.500548e+08</td>\n",
+       "      <td>6988.628164</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          ptflops_mean   ptflops_std     thop_mean      thop_std\n",
+       "net_size                                                        \n",
+       "b10c128   1.053432e+09   9348.777258  1.052373e+09   9318.170885\n",
+       "b15c192   3.537091e+09  11684.545004  3.534840e+09  11647.713606\n",
+       "b20c256   8.394444e+09  14019.621081  8.390522e+09  13977.256327\n",
+       "b40c256   1.670709e+10  16354.697158  1.669944e+10  16306.799048\n",
+       "b60c320   3.889138e+10  18689.773234  3.887721e+10  18636.341769\n",
+       "b6c96     3.505805e+08   7013.009512  3.500548e+08   6988.628164"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Check we get low std in measurements\n",
+    "gb = df.groupby(\"net_size\")\n",
+    "df_mean = pd.DataFrame(dict(\n",
+    "    ptflops_mean=gb.ptflops_macs.mean(),\n",
+    "    ptflops_std=gb.ptflops_macs.std(),\n",
+    "    thop_mean=gb.thop_macs.mean(),\n",
+    "    thop_std=gb.thop_macs.std(),\n",
+    "))\n",
+    "df_mean"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'b10c128': 1052902056.7067871,\n",
+       " 'b15c192': 3535965536.369873,\n",
+       " 'b20c256': 8392483407.783936,\n",
+       " 'b40c256': 16703260895.197998,\n",
+       " 'b60c320': 38884293414.61206,\n",
+       " 'b6c96': 350317665.0437012}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "macs = (df_mean.ptflops_mean + df_mean.thop_mean) / 2\n",
+    "macs_dict = dict(zip(df_mean.index, macs))\n",
+    "macs_dict"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Compute how many FLOPs KataGo took to train"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8.272999624612053e+22"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# https://github.com/lightvector/KataGo/blob/12b8dd4ce74367b4efa4678c9fe11597f55929f5/cpp/configs/training/selfplay8b20.cfg#L96\n",
+    "visits_per_row = 1000\n",
+    "\n",
+    "tot_flops = 0\n",
+    "prv_rows = 0\n",
+    "for x in df_nets.query(\"rows <= 2898845681 & net_size != 'b60c320'\").sort_values(\"rows\").reset_index(drop=True).itertuples():\n",
+    "    cur_rows = x.rows\n",
+    "\n",
+    "    # 2 FLOPS per MAC\n",
+    "    cur_flops = 2 * macs_dict[x.net_size] * visits_per_row * (cur_rows - prv_rows)\n",
+    "    tot_flops += cur_flops\n",
+    "\n",
+    "    prv_rows = cur_rows\n",
+    "\n",
+    "tot_flops"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "go-attack",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.13"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "18ad8d816b0438bcdfb77328a8ad028de3abbf4e5e2b82a5cc55004434e63d0c"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/requirements.txt
+++ b/notebooks/requirements.txt
@@ -3,6 +3,16 @@
 # For Jupyter notebooks
 ipykernel
 
+# Libs needed by submodules/KataGo-pytorch-rewrite
+torch==1.13.1
+torchaudio==0.13.1
+torchvision==0.14.1
+packaging==22.0
+
+# For measuring FLOPs of models
+ptflops
+thop
+
 # tbparse stuff
 tbparse
 tensorboard
@@ -22,6 +32,7 @@ seaborn
 statsmodels
 
 # Utilities
+beautifulsoup4
 black
 flake8
 isort

--- a/notebooks/requirements.txt
+++ b/notebooks/requirements.txt
@@ -35,6 +35,7 @@ statsmodels
 beautifulsoup4
 black
 flake8
+GitPython
 isort
 ipywidgets
 jupyterlab


### PR DESCRIPTION
The number of FLOPs used by KataGo is estimated in `notebooks/iclr2022/estimate-flops-katago.ipynb`.
We perform the estimate by:
1. Counting the number of data rows for each model as specified on https://katagotraining.org/networks/.
2. For each model, we count the number of FLOPs used in one forward pass of the model by using the `ptflops` and `thop` libraries. We use the newly written pytorch version of KataGo for this (added as a submodule).

The number of FLOPs used to train our adversary is estimated in `notebooks/iclr2022/estimate-flops-adv.ipynb`. We perform this estimate by:
1. Borrowing the model FLOPs computations from the previous notebook.
2. Parsing all games, and for each game computing how many FLOPs it took to run that game.

We assume the selfplay/victimplay dominates the total compute.

---

Updated compute estimates:
* KataGo Latest took 8.27 x 10^22 FLOPs to train.
* Our pass adversary took 1.13 x 10^20 FLOPs to train (0.14% of KataGo's compute)
* Our cyclic adversary (paper version) took 1.13 x 10^21 FLOPs to train (1.37% of KataGo's compute)
* Our cyclic adversary (super long run; eval'd against 1mil visit victim) took 9.58 x 10^21 FLOPs to train (11.6% of KataGo's compute).